### PR TITLE
Fix hardin_rocke_f_factors.R for large samples

### DIFF
--- a/R/hardin_rocke_f_factors.R
+++ b/R/hardin_rocke_f_factors.R
@@ -20,7 +20,11 @@ croux_hesbroeck_asymptotic <- function(n, dimension){
   a2 <- rchisq(10000,dimension, h/n)
   c <- sum(a1 < a2)/(10000*h/n)
   factors <- c * (m - dimension + 1)/(dimension * m)
-  cutoff <- qf(0.993, dimension, m - dimension + 1)
+  if(m >= dimension){
+    cutoff <- qf(0.993, dimension, m - dimension + 1)
+  }else{ #for large dimension and m, we assume that the m_asy is a good estimator 
+    m <- m_asy
+  }
   list(factor1 = factors, factor2 = cutoff)
 }
 


### PR DESCRIPTION
Use the asymptotic estimation of the degrees of freedom if the dimension and n is large. Avoid a warning that hampers the estimation of the cutoff to unmask outliers in msplot.